### PR TITLE
fix(deps): add packaging requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setuptools.setup(
     install_requires=(
         "google-api-core[grpc] >= 1.22.2, < 2.0.0dev",
         "proto-plus >= 1.4.0",
-        "packaging >= 14.3"
+        "packaging >= 14.3",
     ),
     python_requires=">=3.6",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setuptools.setup(
     install_requires=(
         "google-api-core[grpc] >= 1.22.2, < 2.0.0dev",
         "proto-plus >= 1.4.0",
+        "packaging >= 14.3"
     ),
     python_requires=">=3.6",
     classifiers=[

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -21,3 +21,4 @@
 # Then this file should have foo==1.14.0
 google-api-core==1.22.2
 proto-plus==1.4.0
+packaging==14.3


### PR DESCRIPTION
Add packaging requirement. packaging.version
              is used for a version comparison in transports/base.py and is needed after the upgrade to gapic-generator-python 0.46.3