### PR TITLE
chore: revert owlbot main branch templates

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -44,31 +44,3 @@ s.move(
 
 s.shell.run(["nox", "-s", "blacken"], hide_output=False)
 
-# ----------------------------------------------------------------------------
-# Main Branch migration
-# ----------------------------------------------------------------------------
-
-s.replace(
-  "*.rst",
-  "master",
-  "main"
-)
-
-s.replace(
-  "*.rst",
-  "google-cloud-python/blob/main",
-  "google-cloud-python/blob/master"
-)
-
-s.replace(
-  "CONTRIBUTING.rst",
-  "kubernetes/community/blob/main",
-  "kubernetes/community/blob/master"
-)
-
-s.replace(
-  ".kokoro/*",
-  "master",
-  "main"
-)
-


### PR DESCRIPTION
Reverts main branch template for OwlBot that were included for the main branch integration.