### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "networkconnectivity",
     "name_pretty": "Network Connectivity Center",
     "product_documentation": "https://cloud.google.com/network-connectivity/",
-    "client_documentation": "https://googleapis.dev/python/networkconnectivity/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/networkconnectivity/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ inconsistencies, etc.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-network-connectivity.svg
    :target: https://pypi.org/project/google-cloud-network-connectivity/
 .. _Network Connectivity Center: https://cloud.google.com/network-connectivity/
-.. _Client Library Documentation: https://googleapis.dev/python/networkconnectivity/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/networkconnectivity/latest
 .. _Product Documentation:  https://cloud.google.com/network-connectivity/
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.